### PR TITLE
Updated README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,12 +6,9 @@ Cakefile and put it in your project.
 
 # Install
 
-```
-npm install get-post -g
-
-# nav to your project folder
-
-get https://raw.github.com/twilson63/cakefile-template/master/Cakefile >> Cakefile
+```bash
+# In your project directory...
+curl https://raw.github.com/twilson63/cakefile-template/master/Cakefile >> Cakefile
 
 ```
 # Usage
@@ -21,7 +18,7 @@ get https://raw.github.com/twilson63/cakefile-template/master/Cakefile >> Cakefi
 Put all of your coffee-script in the src folder, it will compile all coffee-script
 in your lib folder, using the build command.
 
-```
+```bash
 cake build
 ```
 
@@ -29,7 +26,7 @@ cake build
 
 If you want to compile as you write your code, invoke the watch command.
 
-```
+```bash
 cake watch
 ```
 
@@ -37,13 +34,13 @@ cake watch
 
 If you want to run your spec tests, assuming you are using jasmine-node.
 
-```
+```bash
 cake spec
 ```
 
 ## Documenting
 
-```
+```bash
 cake docs
 ```
 


### PR DESCRIPTION
Using the current version of get-post to fetch the Cakefile gives a result full of newlines. I think it's because get-post is expecting JSON...

"fs            = require 'fs'\n{print}       = require 'util'\n{spawn, exec} = require 'child_process'\n\n# ANSI Terminal Colors\nbold = '\033[0;1m'\ngreen = '\033[0;32m'\nreset = '\033[0m'\nred = '\033[0;31m'\n\nlog = (message, color, explanation) ->\n  console.log color + message + reset + ' ' + (explanation or '')\n\nbuild = (watch, callback) ->\n  if typeof watch is 'function'\n    callback = watch\n    watch = false\n  options = ['-c', '-o', 'lib', 'src']\n  options.unshift '-w' if watch\n\n  coffee = spawn 'coffee', options\n  coffee.stdout.on 'data', (data) -> print data.toString()\n  coffee.stderr.on 'data', (data) -> log data.toString(), red\n  coffee.on 'exit', (status) -> callback?() if status is 0\n\nspec = (callback) ->\n  options = ['spec', '--coffee']\n  spec = spawn 'jasmine-node', options\n  spec.stdout.on 'data', (data) -> print data.toString()\n  spec.stderr.on 'data', (data) -> log data.toString(), red\n  spec.on 'exit', (status) -> callback?() if status is 0\n\n\ntask 'docs', 'Generate annotated source code with Docco', ->\n  fs.readdir 'src', (err, contents) ->\n    files = (\"src/#{file}\" for file in contents when /\.coffee$/.test file)\n    docco = spawn 'docco', files\n    docco.stdout.on 'data', (data) -> print data.toString()\n    docco.stderr.on 'data', (data) -> log data.toString(), red\n    docco.on 'exit', (status) -> callback?() if status is 0\n\n\ntask 'build', ->\n  build -> log \":)\", green\n\ntask 'spec', 'Run Jasmine-Node', ->\n  build -> spec -> log \":)\", green\n"
