### PR TITLE
Swapping octal literals for hex literals

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -16,10 +16,10 @@ catch err
   which = null
 
 # ANSI Terminal Colors
-bold = '\033[0;1m'
-green = '\033[0;32m'
-reset = '\033[0m'
-red = '\033[0;31m'
+bold = '\x1b[0;1m'
+green = '\x1b[0;32m'
+reset = '\x1b[0m'
+red = '\x1b[0;31m'
 
 # Internal Functions
 #


### PR DESCRIPTION
Zero-prefixed octal literals are errors in CoffeeScript >1.3.0. See:

jashkenas/coffee-script#2135
jashkenas/coffee-script#2021

Hex literals have the advantage of still being compatible with CoffeeScript < 1.3.0.
