### PR TITLE
Pass-through colour in mocha reporters

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -144,9 +144,7 @@ log = (message, color, explanation) -> console.log color + message + reset + ' '
 # **and** on child process exit emit callback if set and status is 0
 launch = (cmd, options=[], callback) ->
   cmd = which(cmd) if which
-  app = spawn cmd, options
-  app.stdout.pipe(process.stdout)
-  app.stderr.pipe(process.stderr)
+  app = spawn(cmd, options, { stdio: [0, 0, 0] })
   app.on 'exit', (status) ->
     if status is 0
       callback()


### PR DESCRIPTION
Mocha reporters detect whether the stdio ports are ttys. If not they suppress colour.

This change tells `spawn` to directly use the parent stdio in the child, thus passing through colour in the mocha reporters.
